### PR TITLE
Fix __meta_consul_tag to be __meta_consul_tags

### DIFF
--- a/8/8-20-prometheus.yml
+++ b/8/8-20-prometheus.yml
@@ -3,6 +3,6 @@ scrape_configs:
    consul_sd_configs:
     - server: 'localhost:8500'
    relabel_configs:
-    - source_labels: [__meta_consul_tag]
+    - source_labels: [__meta_consul_tags]
       regex:  '.*,prod,.*'
       action: keep

--- a/8/8-21-prometheus.yml
+++ b/8/8-21-prometheus.yml
@@ -3,6 +3,6 @@ scrape_configs:
    consul_sd_configs:
     - server: 'localhost:8500'
    relabel_configs:
-    - source_labels: [__meta_consul_tag]
+    - source_labels: [__meta_consul_tags]
       regex:  '.*,(prod|staging|dev),.*'
       target_label: env


### PR DESCRIPTION
It seems that `__meta_consul_tag` should be `__meta_consul_tags`.

> __meta_consul_tags: the list of tags of the target joined by the tag separator

- https://prometheus.io/docs/prometheus/latest/configuration/configuration/

I also reported this error on Errata of your book.